### PR TITLE
bug/solve isse comparison pages missing unit type information

### DIFF
--- a/src/components/Pop-Up-Modal/EditCQ.vue
+++ b/src/components/Pop-Up-Modal/EditCQ.vue
@@ -148,7 +148,8 @@ export default {
         });
         this.processElement();
 
-        this.unitResult = await CallofQuotationController.getUnittype(id);
+        const getCQUnitData = await CallofQuotationController.getUnittype(id);
+        this.unitResult = getCQUnitData.cqUnitTypes;
 
       } catch (error) {
         const FailMessage =  `Error Message: ${error.message || 'Unknown Data.'}`;


### PR DESCRIPTION
1. Forget to change when call getUnittype need call one more array

![image](https://github.com/user-attachments/assets/df7d32a2-fa69-4c7f-a0a5-d02d1dda1730)
