### PR TITLE
bug/Add description header logic incorrect, please follow production

### DIFF
--- a/src/components/Tables/ComparisonTable.vue
+++ b/src/components/Tables/ComparisonTable.vue
@@ -627,7 +627,7 @@ export default {
             // Update previousCreateTime for the next iteration
             previousCreateTime = currentCreateTime;
 
-            if (getQuotation.length <= 0 || (parseFloat(formData.adj_quantity) === 0.00 || formData.description_unit.trim() === "" ) ) {
+            if (getQuotation.length <= 0 || (parseFloat(formData.adj_quantity) === 0.00) ) {
               head1Counter++;
             
               const head1Row = document.createElement('tr');

--- a/src/pages/Layout/EditQuotation.vue
+++ b/src/pages/Layout/EditQuotation.vue
@@ -37,7 +37,7 @@
                 </thead>
                 <tbody>
                   <tr v-for="(formData, formIndex) in Description" :key="'form-'+formIndex">
-                    <template v-if="formData.quotation.length <= 0 || (parseFloat(formData.adj_quantity) === 0.00 && formData.description_unit.trim() === '')  ">
+                    <template v-if="formData.quotation.length <= 0 || parseFloat(formData.adj_quantity) === 0.00  ">
                       <td><b>{{ formIndex + 1 }}</b></td>
                       <td><b>{{ formData.element || '' }}</b></td>
                       <td><b>{{ formData.sub_element || '' }}</b></td>

--- a/src/pages/Layout/Quotation.vue
+++ b/src/pages/Layout/Quotation.vue
@@ -313,7 +313,7 @@ export default {
         const getQuotation = formData.quotation;
 
         
-        if (getQuotation.length <= 0 || (parseFloat(formData.adj_quantity) === 0.00 || formData.description_unit.trim() === "" ) ) {
+        if (getQuotation.length <= 0 || parseFloat(formData.adj_quantity) === 0.00 ) {
           head1Counter++;
           prevHead1 = formData.description_item;
 

--- a/src/pages/Layout/Remeasurement.vue
+++ b/src/pages/Layout/Remeasurement.vue
@@ -33,7 +33,7 @@
                 </thead>
                 <tbody>
                   <tr v-for="(formData, formIndex) in Description" :key="'form-' + formIndex">
-                    <template v-if="formData.quotation.length <= 0 || (parseFloat(formData.adj_quantity) === 0.00 || formData.description_unit.trim() === '')  ">
+                    <template v-if="formData.quotation.length <= 0 || parseFloat(formData.adj_quantity) === 0.00  ">
                       <td v-if="getMaxQuotation <= 2"> 
                         <input  
                           type="checkbox" 


### PR DESCRIPTION
1.When there is no unit, but the unit type quantity and budget rate have values, they should be displayed in the '**BODY**', not in the '**HEAD**'.

URL : /comparison?cqID=532&projectID=132
![image](https://github.com/user-attachments/assets/c30e2051-cfdb-4d0f-a82f-d8b108c061ab)
![image](https://github.com/user-attachments/assets/3692e002-8e36-4364-81d7-52fb32e4b8b0)
