### PR TITLE
Bug/Awarding target date not saved and remeasurement not displayed

### DIFF
--- a/src/components/Pop-Up-Modal/EditCQ.vue
+++ b/src/components/Pop-Up-Modal/EditCQ.vue
@@ -48,7 +48,7 @@
             <p style="text-align: left;">Awarding Target Date : </p>
             <input
               type="text"
-              :value="formatDate(cquotationData.awading_target_date)"
+              :value="formatDate(cquotationData.awarding_target_date)"
               placeholder="Awarding Target Date"
               class="typeInput"
               readonly

--- a/src/components/Tables/ComparisonTable.vue
+++ b/src/components/Tables/ComparisonTable.vue
@@ -667,10 +667,10 @@ export default {
                 unitQuantityTDs += `<td style="text-align:center;">${this.formatAccounting(cqUnit.adj_quantity)}</td>`;
               });
 
+              const getUnittype_isRemeas = this.Unittype[0];
               let remeasuremntQuantityTDs = '';
-              if (formData.remeasurement_quantity >= 0) {
-                remeasuremntQuantityTDs = `${!isHide ? `<td>${this.formatAccounting(formData.remeasurement_quantity)}</td>` : ''}`;
-               
+              if (formData.remeasurement_quantity >= 0 && getUnittype_isRemeas.is_remeasurement === true) {
+                  remeasuremntQuantityTDs = `${!isHide ? `<td>${this.formatAccounting(formData.remeasurement_quantity)}</td>` : ''}`;
               }
 
 

--- a/src/components/Tables/CreatecqTable.vue
+++ b/src/components/Tables/CreatecqTable.vue
@@ -74,7 +74,7 @@ export default {
   methods: {
     addModule() {
       const formData = { ...this.modules[0], selected: true }; 
-      this.$emit('form-submitted', formData); 
+       this.$emit('form-submitted', formData); 
     }
    
   },

--- a/src/models/CallQuotationModels.js
+++ b/src/models/CallQuotationModels.js
@@ -15,7 +15,7 @@ const CallQuotationModels = {
         createdAt: config.createdAt,
         updatedAt: config.updatedAt,
         actuallDoneDate: config.actual_done_date,
-        awadingtargetdate: config.awading_target_date,
+        awadingtargetdate: config.awarding_target_date,
         remarks: config.remarks,
         budget_amount: config.budget_amount,
         adj_budget_amount: config.adj_budget_amount,

--- a/src/models/LawoModels.js
+++ b/src/models/LawoModels.js
@@ -19,7 +19,7 @@ const LawoModels = {
         createdAt: config.createdAt,
         updatedAt: config.updatedAt,
         actuallDoneDate: config.actual_done_date,
-        awadingtargetdate: config.awading_target_date,
+        awadingtargetdate: config.awarding_target_date,
         remarks: config.remarks,
         budget_amount: config.budget_amount,
         adj_budget_amount: config.adj_budget_amount,

--- a/src/pages/Comparison.vue
+++ b/src/pages/Comparison.vue
@@ -65,7 +65,7 @@
             </div>
             <div class="md-layout-item md-medium-size-33 md-xsmall-size-100 md-size-11">
               <h7>Awarding Target Data :</h7>
-              <h5 class="titleHeader">{{ formatDate(callQuotation.awading_target_date) ? formatDate(callQuotation.awading_target_date) : '-' }}</h5>
+              <h5 class="titleHeader">{{ formatDate(callQuotation.awarding_target_date) ? formatDate(callQuotation.awarding_target_date) : '-' }}</h5>
             </div>
             <button class="transparentButton"  @click="editCallQuotation(callQuotation.id)" >
             <div class="tooltip">

--- a/src/services/controllers/CallofQuotationController.js
+++ b/src/services/controllers/CallofQuotationController.js
@@ -93,7 +93,7 @@ const CallofQuotationController = {
             trade: updatedData.trade, 
             trade_location1: updatedData.trade_location1, 
             actual_calling_quotation_date: updatedData.actual_calling_quotation_date, 
-            awading_target_date: updatedData.awading_target_date, 
+            awarding_target_date: updatedData.awarding_target_date, 
             remarks: updatedData.remarks
           }, { headers })
         ]);
@@ -157,7 +157,7 @@ const CallofQuotationController = {
           trade: formData.trade,
           trade_location1: formData.location,
           actual_calling_quotation_date: formData.callingquotationDate,
-          awading_target_date: formData.awadingtaget,
+          awarding_target_date: formData.awadingtaget,
           remarks: formData.remarks,
           status: 'Pending',
           project_id: projectId


### PR DESCRIPTION
1. Rename the awarding target date then saved it.
![image](https://github.com/user-attachments/assets/5bb9d4f6-d022-49c0-b451-5a5acbe1e728)
  
2. When remeasurement is true, display the data; otherwise, do not display the data.

![image](https://github.com/user-attachments/assets/0802e85a-24a2-4bfb-9adc-31d69d792d04)