### PR TITLE
enhancement/control-quotationButton-and-add-adjFactor-in-edit-modal

### DIFF
--- a/src/components/Pop-Up-Modal/EditCQ.vue
+++ b/src/components/Pop-Up-Modal/EditCQ.vue
@@ -73,6 +73,16 @@
                 readonly
                 style="background-color: #fef4e4;"
               />
+              <p style="text-align: left;">ADJ Factor : </p>
+              <input
+                type="text"
+                v-model="unit.adj_factor"
+                placeholder="Unit Quantity"
+                class="typeInput"
+                readonly
+                style="background-color: #fef4e4;"
+              />
+
               <p style="text-align: left;">Unit Quantity : </p>
               <input
                 type="text"
@@ -82,6 +92,8 @@
                 readonly
                 style="background-color: #fef4e4;"
               />
+
+           
             </div>
           </div>
         </div>
@@ -150,6 +162,7 @@ export default {
 
         const getCQUnitData = await CallofQuotationController.getUnittype(id);
         this.unitResult = getCQUnitData.cqUnitTypes;
+        console.log('this.unitResult',this.unitResult);
 
       } catch (error) {
         const FailMessage =  `Error Message: ${error.message || 'Unknown Data.'}`;

--- a/src/components/Tables/ComparisonTable.vue
+++ b/src/components/Tables/ComparisonTable.vue
@@ -23,8 +23,10 @@
         </form>
       </div>
       <div class="filter-container" v-if="!isLoading">
-        <a :href="'quotation?cqId=' + cqId"><button type="button" class="btn-save" style="margin-right: 10px"   v-if="isPending" >
-          <md-icon style="color: antiquewhite;margin-right: 3px;">assignment_add</md-icon> Quotation</button></a>
+        <a :href="'quotation?cqId=' + cqId">
+          <button type="button" class="btn-save" style="margin-right: 10px"   v-if="isPending && QuotationName.length >= 2" >
+          <md-icon style="color: antiquewhite;margin-right: 3px;">assignment_add</md-icon> Quotation</button>
+        </a>
         <button @click="toggleFilter" class="transparentButton" style="margin-right: 10px" >
           <div class="tooltip" style="width: 178px !important;">
             <span class="tooltiptext">Hide unit type information. Please click to open see details.</span>


### PR DESCRIPTION
1. If a quotation exists, show the quotation button; otherwise, do not display the button.
![image](https://github.com/user-attachments/assets/ba987d80-07bf-4f57-9f77-77b30a62f332)

2. Edit the pop-up modal to include the Adj Factor for display.
