### PR TITLE
Enhancement/Control the edit button display when there is no description

### DIFF
--- a/src/components/Tables/ComparisonTable.vue
+++ b/src/components/Tables/ComparisonTable.vue
@@ -18,7 +18,7 @@
             <label for="coloration-low"  class="hidden-toggles__label"  @click="navigateTo('description')" >Add</label>
             <span class="hidden-toggles__label static-label">Description</span>
             <input name="coloration-level" type="radio" id="coloration-high" class="hidden-toggles__input" value="edit" v-model="selectedAction"/>
-            <label  for="coloration-high" class="hidden-toggles__label"  @click="navigateTo('remeasurement')">Edit</label>
+            <label  for="coloration-high" class="hidden-toggles__label"  @click="navigateTo('remeasurement')" v-if="processedData.length !== 0">Edit</label>
           </div>
         </form>
       </div>


### PR DESCRIPTION
1. If there is no description, don't show the edit button; otherwise, show it if there is a description.

![image](https://github.com/user-attachments/assets/4110c890-14fd-4566-8b56-9a7e54fa0f65)
