### PR TITLE
bug/Change: Update unit type quantity to use number format.

### DIFF
--- a/src/components/Import/DescriptionImport.vue
+++ b/src/components/Import/DescriptionImport.vue
@@ -273,8 +273,9 @@ export default {
 
           // If the unit type exists in the sanitized import data 
           if (sanitizedObjectKeys.hasOwnProperty(combineObjects)) {
-            matchedValues[unit.id] = `${sanitizedObjectKeys[combineObjects]}`;
+            matchedValues[unit.id] = parseFloat(sanitizedObjectKeys[combineObjects].replace(/,/g, ''));
           }
+
         });
         let valueSubconDetails;
         if (getSubconDetails.length === 0) {
@@ -305,7 +306,7 @@ export default {
 
                 if (sanitizedObjectKeys.hasOwnProperty(getSubconObject)) {
                     console.log('Found key in object:', getSubconObject);  // Debug log to verify key existence
-                    getSubconValue[subcon.id] = `${sanitizedObjectKeys[getSubconObject]}`;
+                    getSubconValue[subcon.id] = parseFloat(sanitizedObjectKeys[getSubconObject].replace(/,/g, '')); 
                 }
             });
         }


### PR DESCRIPTION
1. Enhancement: When importing Excel to save data, ensure that the amount or quantity uses number format instead of string format.
![image](https://github.com/user-attachments/assets/391d3925-3c3c-40f9-a638-1c145f77c2ed)
