### PR TITLE
Bug/Hide "()" if subcon name is null

### DIFF
--- a/src/components/Import/DescriptionImport.vue
+++ b/src/components/Import/DescriptionImport.vue
@@ -66,7 +66,7 @@
               v-for="(subcon, index) in SubconList.length > 0 ? SubconList : [{ Subcon: { name: 'Budget' } }]" 
               :key="index"
             >
-              {{ subcon.Subcon.name }} <span v-if="subcon.Subcon.name !== 'Budget' && subcon.name !== ''">({{ subcon.name }})</span>
+              {{ subcon.Subcon.name }} <span v-if="subcon.name && subcon.name !== 'Budget'">({{ subcon.name }})</span>
             </th>
 
           </tr>


### PR DESCRIPTION
**Before:**  
1. Before, when importing the BQ description, if the subcon quotation name is missing, the display view shows "()" and prevents upload to the system.

**After:**  
1. After the change, when importing the BQ description, if the subcon quotation name is missing, the display view hides "()" and allows upload to the system.