### PR TITLE
Enhancement/When the description includes unit data, it acts as the b…

### DIFF
--- a/src/components/Tables/ComparisonTable.vue
+++ b/src/components/Tables/ComparisonTable.vue
@@ -629,7 +629,9 @@ export default {
             // Update previousCreateTime for the next iteration
             previousCreateTime = currentCreateTime;
 
-            if (getQuotation.length <= 0 || (parseFloat(formData.adj_quantity) === 0.00) ) {
+            console.log('formData',formData.description_unit);
+
+            if (!formData.description_unit) {
               head1Counter++;
             
               const head1Row = document.createElement('tr');
@@ -639,7 +641,6 @@ export default {
                 ${!isHide ? `<td><b><u>${formData.sub_element || ''}</u></b></td>` : ''}
                 ${!isHide ? `<td><b><u>${formData.description_sub_sub_element || ''}</u></b></td>` : ''}
                 <td style="padding-left:10px !important" class="td-max-width"><b><u>${formData.description_item}</u></b></td>
-                <td><b>${formData.description_unit || ''}</b></td>
               `;
               tableBody.appendChild(head1Row);
 

--- a/src/pages/Layout/EditQuotation.vue
+++ b/src/pages/Layout/EditQuotation.vue
@@ -47,14 +47,13 @@
                 </thead>
                 <tbody>
                   <tr v-for="(formData, formIndex) in Description" :key="'form-'+formIndex">
-                    <template v-if="formData.quotation.length <= 0 || parseFloat(formData.adj_quantity) === 0.00  ">
+                    <template v-if="!formData.description_unit">
                       <td><b>{{ formIndex + 1 }}</b></td>
                       <td><b>{{ formData.element || '' }}</b></td>
                       <td><b>{{ formData.sub_element || '' }}</b></td>
                       <td><b>{{ formData.description_sub_sub_element || '' }}</b></td>
                       <td class="td-max-width"><b>{{ formData.description_item }}</b></td>
-                      <td><b>{{ formData.description_unit || '' }}</b></td>
-                      <td colspan="8"></td>
+                      <td colspan="9"></td>
                     </template>
                     <template v-else>
                       <td>{{ formIndex + 1 }}</td>

--- a/src/pages/Layout/Quotation.vue
+++ b/src/pages/Layout/Quotation.vue
@@ -359,7 +359,7 @@ export default {
         const getQuotation = formData.quotation;
 
         
-        if (getQuotation.length <= 0 || parseFloat(formData.adj_quantity) === 0.00 ) {
+        if (!formData.description_unit) {
           head1Counter++;
           prevHead1 = formData.description_item;
 
@@ -370,7 +370,6 @@ export default {
             <td><b>${formData.sub_element || ''}</b></td>
             <td><b>${formData.description_sub_sub_element || ''}</b></td>
             <td class="td-max-width"><b>${formData.description_item}</b></td>
-            <td><b>${formData.description_unit || ''}</b></td>
           `;
           tableBody.appendChild(head1Row);
 

--- a/src/pages/Layout/Remeasurement.vue
+++ b/src/pages/Layout/Remeasurement.vue
@@ -51,7 +51,7 @@
                 </thead>
                 <tbody>
                   <tr v-for="(formData, formIndex) in Description" :key="'form-' + formIndex">
-                    <template v-if="formData.quotation.length <= 0 || parseFloat(formData.adj_quantity) === 0.00  ">
+                    <template v-if="!formData.description_unit">
                       <td v-if="getMaxQuotation <= 2"> 
                         <input  
                           type="checkbox" 
@@ -73,7 +73,6 @@
                       <td><b>{{ formData.sub_element || '' }}</b></td>
                       <td><b>{{ formData.description_sub_sub_element || '' }}</b></td>
                       <td class="td-max-width"><b>{{ formData.description_item }}</b></td>
-                      <td><b>{{ formData.description_unit || '' }}</b></td>
                     </template>
                     <template v-else>
                       <td  v-if="getMaxQuotation <= 2">


### PR DESCRIPTION
**Before:**
- The BQ description displays as "HEAD" when `adj_quantity` is 0.
- The BQ description displays as "BODY" when `adj_quantity` has data.

**After:**
- The BQ description displays as "HEAD" when the unit is empty.
- The BQ description displays as "BODY" when the unit has data.