### PR TITLE
enhancement/Edit-Description-cannot-edit-without-unit

### DIFF
--- a/src/components/Pop-Up-Modal/EditDescription.vue
+++ b/src/components/Pop-Up-Modal/EditDescription.vue
@@ -44,8 +44,10 @@
             v-model="processedData.description_unit"
             placeholder="Unit"
             class="typeInput"
+            @blur="handleEmptyUnit"
           />
         </div>
+
 
       </div>
       <button class="btn-save" aria-label="close" @click.stop="closeEditModal">Close</button>
@@ -79,6 +81,11 @@ export default {
     }
   },
   methods: {
+    handleEmptyUnit() {
+      if (!this.processedData.description_unit.trim()) {
+        this.processedData.description_unit = '-';
+      }
+    },
     closeEditModal() {
       this.$emit("close");
     },

--- a/src/components/Pop-Up-Modal/EditDescription.vue
+++ b/src/components/Pop-Up-Modal/EditDescription.vue
@@ -36,13 +36,17 @@
           placeholder="Description Item"
           class="typeInput"
         />
-        <p>Unit : </p>
-        <input
-          type="text"
-          v-model="processedData.description_unit"
-          placeholder="Unit"
-          class="typeInput"
-        />
+
+        <div v-if="processedData.description_unit">
+          <p>Unit:</p>
+          <input
+            type="text"
+            v-model="processedData.description_unit"
+            placeholder="Unit"
+            class="typeInput"
+          />
+        </div>
+
       </div>
       <button class="btn-save" aria-label="close" @click.stop="closeEditModal">Close</button>
       <button class="btn-save" aria-label="close" @click.stop="saveAndCloseModal()">Save</button>


### PR DESCRIPTION
**Before:**  
- The "Edit Description" pop-up modal could edit the unit, with no distinction between the header and body.  
- If the unit data was left empty in the "Edit Description" pop-up modal, the column would still be displayed.  

**After:**  
- The "Edit Description" pop-up modal can only edit the unit when the description is in the body section.  
- If the unit data is updated to be empty in the "Edit Description" pop-up modal, it will automatically be replaced with `'-'`, and the unit will not be moved to the head section.  